### PR TITLE
Exercise 2 layout adjustments

### DIFF
--- a/src/components/CharacterEditor/CharacterEditor.module.css
+++ b/src/components/CharacterEditor/CharacterEditor.module.css
@@ -8,6 +8,7 @@
 
 .header {
   padding-bottom: 64px;
+  max-width: 65%;
 }
 
 .title {

--- a/src/components/CharacterEditor/CharacterEditor.module.css
+++ b/src/components/CharacterEditor/CharacterEditor.module.css
@@ -28,4 +28,5 @@
 }
 
 .controlColumn {
+  max-width: 50%;
 }

--- a/src/components/CharacterEditor/CharacterEditor.module.css
+++ b/src/components/CharacterEditor/CharacterEditor.module.css
@@ -25,6 +25,11 @@
 }
 
 .characterWrapper {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: 35%;
+  min-height: 500px;
 }
 
 .controlColumn {


### PR DESCRIPTION
## Exercise 2: Layout adjustments
Next, let's tackle the biggest visual issue: the layout.

We have a MaxWidthWrapper constraining the max width, but everything is super wide within it.

Our header should be 65% of the available width, and our control-panel column should be 50%.

![image](https://user-images.githubusercontent.com/29380502/205551277-991bea76-3a12-42ee-8925-2d8827305e34.png)

The character (the big illustration) should use fixed positioning, and it should occupy the space cleared by the above width tweaks.

Give the character a minimum height of 500px. On smaller windows, this means the character won't fit in the viewport:

![image](https://user-images.githubusercontent.com/29380502/205551297-f0154100-8d44-477b-bdc0-a5d46e6f5617.png)
