### PR TITLE
Exercise 3: Handle panel overflow

### DIFF
--- a/src/components/ButtonRow/ButtonRow.module.css
+++ b/src/components/ButtonRow/ButtonRow.module.css
@@ -1,2 +1,3 @@
 .buttonRow {
+  width: max-content;
 }

--- a/src/components/ControlPane/ControlPane.module.css
+++ b/src/components/ControlPane/ControlPane.module.css
@@ -10,6 +10,7 @@
     to deal with it yet!
   */
   margin-bottom: 32px;
+  overflow-x: auto;
 }
 
 .title {


### PR DESCRIPTION
### Exercise 3: Overflow

Each control panel features a number of customizations. For control panels with too many options, a horizontal scrollbar should be introduced:

![image](https://user-images.githubusercontent.com/29380502/205552279-e330fb39-37e2-4bc2-aa86-0cd0729cce1b.png)

