### PR TITLE
Exercise 4: Perspective decoration

### DIFF
--- a/src/components/CharacterEditor/CharacterEditor.module.css
+++ b/src/components/CharacterEditor/CharacterEditor.module.css
@@ -3,7 +3,14 @@
   padding-bottom: 64px;
 }
 
-.maxWidthWrapper {
+.characterEditor::before {
+  content: '';
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 40%;
+  background-color: hsl(195deg, 20%, 86%);
 }
 
 .header {
@@ -34,4 +41,5 @@
 
 .controlColumn {
   max-width: 50%;
+  isolation: isolate;
 }


### PR DESCRIPTION
To help add a bit of perspective, a light gray bar should extend across the bottom 40% of the screen:

![image](https://user-images.githubusercontent.com/29380502/205559236-af3178d0-ac60-4beb-98f3-416612ff8b24.png)

You can use the background color hsl(195deg, 20%, 86%).

For bonus points, solve this challenge without setting any z-indexes.